### PR TITLE
Fix code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
         "pino-pretty": "^11.2.2",
         "postgres": "^3.4.4",
         "ua-parser-js": "^1.0.39",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "validator": "^13.12.0"
     },
     "devDependencies": {
         "@types/node": "^22.5.5",

--- a/src/handlers/track.handlers.ts
+++ b/src/handlers/track.handlers.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import validator from 'validator';
 import { and, count, desc, eq, sql } from 'drizzle-orm';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import UAParser from 'ua-parser-js';
@@ -23,6 +24,9 @@ export const isEmailRead = async (request: FastifyRequest, reply: FastifyReply) 
             const os = result?.os?.name;
             const browser = result?.browser?.name;
             const realIp = ip.split(":")[0];
+            if (!validator.isIP(realIp)) {
+                return reply.status(400).send({ error: 'Invalid IP address' });
+            }
             const geoResponse = await axios.get(`https://ipinfo.io/${realIp}/geo?token=843b85132fe7ea`);
             const { city, region, country } = geoResponse.data;
             context = {


### PR DESCRIPTION
Fixes [https://github.com/anishkumar127/email-tracking-system-fastify-postgresql/security/code-scanning/1](https://github.com/anishkumar127/email-tracking-system-fastify-postgresql/security/code-scanning/1)

To fix the SSRF vulnerability, we should validate the `realIp` value before using it in the URL. One way to do this is to ensure that the `realIp` is a valid IP address. This can be done using a well-known library like `validator` to check if the `realIp` is a valid IP address. If the validation fails, we can handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
